### PR TITLE
Do not create SQS queue if DoNotCreateQueueIfNotExists config is true

### DIFF
--- a/sqs/subscriber.go
+++ b/sqs/subscriber.go
@@ -297,6 +297,10 @@ func (s *Subscriber) SubscribeInitializeWithContext(ctx context.Context, topic s
 		return nil
 	}
 
+	if s.config.DoNotCreateQueueIfNotExists {
+		return fmt.Errorf("queue for topic '%s' doesn't exists", topic)
+	}
+
 	input, err := s.config.GenerateCreateQueueInput(ctx, resolvedQueue.QueueName, s.config.QueueConfigAttributes)
 	if err != nil {
 		return fmt.Errorf("cannot generate input for queue %s: %w", topic, err)


### PR DESCRIPTION
When using the `SubscribeInitializeWithContext` method I don't want to create the SQS queue if it doesn't exist.
I set the DoNotCreateQueueIfNotExists config to be true but still the queue was created.